### PR TITLE
Allow usage of a custom interface in Prometheus constructor

### DIFF
--- a/buildbot_prometheus/prometheus.py
+++ b/buildbot_prometheus/prometheus.py
@@ -71,9 +71,10 @@ class Prometheus(service.BuildbotService):
     name = "Prometheus"
     namespace = 'buildbot'
 
-    def __init__(self, port=9101, **kwargs):
+    def __init__(self, port=9101, interface='', **kwargs):
         service.BuildbotService.__init__(self, **kwargs)
         self.port = port
+        self.interface = interface
         self.server = None
         self.consumers = []
         self.registry = None
@@ -94,7 +95,7 @@ class Prometheus(service.BuildbotService):
         yield service.BuildbotService.startService(self)
         root = Resource()
         root.putChild(b'metrics', MetricsResource(registry=self.registry))
-        self.server = reactor.listenTCP(self.port, Site(root))
+        self.server = reactor.listenTCP(self.port, Site(root), interface=self.interface)
         log.msg("Prometheus service starting on {}".format(self.server.port))
 
     @defer.inlineCallbacks


### PR DESCRIPTION
Adds the possibility to specify a custom interface to Prometheus constructor.

The default value `interface=''` comes from twisted `reactor.listenTCP` (cf: https://twistedmatrix.com/documents/12.2.0/api/twisted.internet.interfaces.IReactorTCP.listenTCP.html) in order to keep the original behaviour